### PR TITLE
✨ Added issue details to unreleased milestones list

### DIFF
--- a/commands/unreleased.js
+++ b/commands/unreleased.js
@@ -36,6 +36,22 @@ async function handle(org, octokit, callback) {
                   " pr(s) ready to release"
               )
             );
+            const issues = await octokit.issues.listForRepo({
+              owner: response.data[index].owner.login,
+              repo: response.data[index].name,
+              milestone: milestones.data[mindex].number,
+              state: "closed"
+            });
+            for (let iindex = 0; iindex < issues.data.length; iindex++) {
+              console.log(
+                chalk.yellow(
+                  "  - [" +
+                    issues.data[iindex].number +
+                    "] " +
+                    issues.data[iindex].title
+                )
+              );
+            }
           }
         }
       }
@@ -67,6 +83,22 @@ async function handle(org, octokit, callback) {
                   " pr(s) ready to release"
               )
             );
+            const issues = await octokit.issues.listForRepo({
+              owner: org,
+              repo: repos.data[index].name,
+              milestone: milestones.data[mindex].number,
+              state: "closed"
+            });
+            for (let iindex = 0; iindex < issues.data.length; iindex++) {
+              console.log(
+                chalk.yellow(
+                  "  - [" +
+                    issues.data[iindex].number +
+                    "] " +
+                    issues.data[iindex].title
+                )
+              );
+            }
           }
         }
       }


### PR DESCRIPTION
This PR adds the list of issues under the milestone when running the unreleased command. This will tell you not only which repositories have closed issues that haven't been released yet, but the actual list of them as well.

<img width="785" alt="Screen Shot 2019-12-08 at 10 09 52 AM" src="https://user-images.githubusercontent.com/140127/70391438-4d920400-19a3-11ea-8deb-8a58806febc7.png">

closes #3 